### PR TITLE
Fixed PlayerInfo being retrieved with wrong Entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+Debug/
+Release/
+generated_proto/
+demoinfogo.exe
+demoinfogo.opensdf
+protobuf-2.5.0/
+test.dem

--- a/demoinfogo/demofiledump.h
+++ b/demoinfogo/demofiledump.h
@@ -84,6 +84,8 @@ struct player_info_t
 	CRC32_t			customFiles[ MAX_CUSTOM_FILES ];
 	// this counter increases each time the server downloaded a new file
 	unsigned char	filesDownloaded;
+	// entity index
+	int				entityID;
 };
 
 struct ExcludeEntry


### PR DESCRIPTION
Fix is required becuase reconnecting clients entity index would be incorrect.

Have updated the logic where players are added and removed from s_PlayerInfos to ensure they have the correct entity ID. Old code code worked, if no players reconnected. Figure it's easier if I demonstrate the bug, and show the fix working.

**From the Major VP vs G2**: http://kpd.io/demos/195
**Demo File:** http://storage.kpd.io/108ae2b45ff49ba8e0b44fdde9e3074d.dem

The following outputs were produced with this command:

>  demoinfogo test.dem -gameevents -nowramup -nofootsteps -extrainfo

Before Fix: http://rchh.co.uk/public/main/csgo-demoinfo/test.txt
After Fix: http://rchh.co.uk/public/main/csgo-demoinfo/test-fix.txt

Running a simple diff will show you the corrections. But the first is seen on line 235, where the before fix has no team or position data, and the fixed file does. Have tested on several 100 demos.