### PR TITLE
Bugfix : Access violation

### DIFF
--- a/demoinfogo/demofiledump.cpp
+++ b/demoinfogo/demofiledump.cpp
@@ -310,9 +310,12 @@ bool HandlePlayerConnectDisconnectEvents( const CSVCMsg_GameEvent &msg, const CS
 			}
 			// mark the player info slot as disconnected
 			player_info_t *pPlayerInfo = FindPlayerInfo( userid );
-			strcpy_s( pPlayerInfo->name, "disconnected" );
-			pPlayerInfo->userID = -1;
-			pPlayerInfo->guid[ 0 ] = 0;
+			if (pPlayerInfo)
+			{
+				strcpy_s( pPlayerInfo->name, "disconnected" );
+				pPlayerInfo->userID = -1;
+				pPlayerInfo->guid[ 0 ] = 0;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Bugfix : Access violation when pPlayerInfo is NULL (ex : a bot disconnect when it's not in s_PlayerInfos)
Occurred in Visual Studio 2015 with a competitive match demo