### PR TITLE
Bugfix for fixed-user-data-size stringtable updates

### DIFF
--- a/demoinfogo/demofiledump.h
+++ b/demoinfogo/demofiledump.h
@@ -57,6 +57,9 @@ struct StringTableData_t
 {
 	char	szName[ 64 ];
 	int		nMaxEntries;
+	int		nUserDataSize;      // not currently used to parse stringtable updates, kept for documentation purposes only
+	int		nUserDataSizeBits;  // not currently used to parse stringtable updates, kept for documentation purposes only
+	int		nUserDataFixedSize; // used to parse stringtable updates
 };
 
 // userinfo string table contains these


### PR DESCRIPTION
I implemented missing support for parsing stringtable updates with fixed user data size. The bug manifested itself as invalid number of bits read from bit stream, resulting in out-of-range std::vector access that led to incorrect parsing of fixed-user-size stringtable updates (but not parsing the initial stringtable creation message).