### PR TITLE
Convenience script for Visual Studio 2019

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,8 @@ generated_proto/
 demoinfogo.exe
 demoinfogo.opensdf
 protobuf-2.5.0/
+protoc-2.5.0-win32/
+.vs/
 test.dem
+Backup
+UpgradeLog.htm

--- a/demoinfogo/README.md
+++ b/demoinfogo/README.md
@@ -10,6 +10,16 @@ Building demoinfogo
 
 ### Windows
 
+#### Visual Studio 2019 (Automated)
+
+Executing the vs19.ps1 PowerShell script will resolve all dependencies, upgrade solution files, and build demoinfogo.exe
+
+```
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& './vs19.ps1'"
+```
+
+#### Visual Studio 2010 (Manual)
+
 In order to build demoinfogo on Windows, follow these steps:
 
 1. Download [protobuf-2.5.0.zip](https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.zip) and extract it into the `demoinfogo` folder. This creates the folder `demoinfogo/protobuf-2.5.0`.

--- a/vs19.ps1
+++ b/vs19.ps1
@@ -1,0 +1,30 @@
+# Download protobuf and protoc
+cmd /c "curl -L https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.zip --output protobuf-2.5.0.zip"
+cmd /c "tar -xzf protobuf-2.5.0.zip -C demoinfogo"
+cmd /c "del protobuf-2.5.0.zip"
+cmd /c "curl -L https://github.com/google/protobuf/releases/download/v2.5.0/protoc-2.5.0-win32.zip --output protoc-2.5.0-win32.zip"
+cmd /c "tar -xzf protoc-2.5.0-win32.zip -C demoinfogo/protoc-2.5.0-win32"
+cmd /c "del protoc-2.5.0-win32.zip"
+
+# Upgrade protobuf sln
+cmd /c "devenv demoinfogo\protobuf-2.5.0\vsprojects\protobuf.sln /Upgrade"
+
+# Include algorithm in zero_copy_stream_impl_lite.cc, min function will be unresolved otherwise
+get-content demoinfogo\protobuf-2.5.0\src\google\protobuf\io\zero_copy_stream_impl_lite.cc | %{$_ -replace "#include <google/protobuf/stubs/stl_util.h>", "#include <google/protobuf/stubs/stl_util.h>`n#include <algorithm>"} | out-file temp
+cmd /c "move /y temp demoinfogo\protobuf-2.5.0\src\google\protobuf\io\zero_copy_stream_impl_lite.cc"
+
+# Define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS for hash_map deprecation
+$projects = "demoinfogo\protobuf-2.5.0\vsprojects\libprotobuf.vcxproj", "demoinfogo\protobuf-2.5.0\vsprojects\libprotobuf-lite.vcxproj", "demoinfogo\protobuf-2.5.0\vsprojects\libprotoc.vcxproj"
+foreach ($project in $projects) {
+    get-content $project | %{$_ -replace "<PreprocessorDefinitions>", "<PreprocessorDefinitions>_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;"} | out-file temp
+    cmd /c "move /y temp $project"
+}
+
+# Build libprotobuf
+cmd /c "devenv demoinfogo\protobuf-2.5.0\vsprojects\protobuf.sln /Build `"Release|Win32`" /Project libprotobuf"
+
+# Upgrade demoinfogo sln
+cmd /c "devenv demoinfogo\demoinfogo.sln /Upgrade"
+
+# Build demoinfogo
+cmd /c "devenv demoinfogo\demoinfogo.sln /Build `"Release|Win32`" /Project demoinfogo"


### PR DESCRIPTION
I added a simple PowerShell script that automates first build for Visual Studio 2019. All protobuf dependencies are resolved automatically. Makes getting started much easier for people who want to move on from VS2010.

Instructions have been added to the second-level README

This script should work out of the box on any modern Windows machine -- PS, tar, and curl are preinstalled with the OS these days.