### PR TITLE
Add support for building with CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ demoinfogo.exe
 demoinfogo.opensdf
 protobuf-2.5.0/
 test.dem
+/out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,3 +3,5 @@ cmake_minimum_required(VERSION 3.19)
 project(csgo-demoinfo)
 
 find_package(protobuf CONFIG REQUIRED)
+
+add_subdirectory(demoinfogo)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(csgo-demoinfo)
+
+find_package(protobuf CONFIG REQUIRED)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,7 +19,7 @@
             }
         },
         {
-            "name": "debug",
+            "name": "Debug",
             "inherits": [
                 "base"
             ],
@@ -28,7 +28,7 @@
             }
         },
         {
-            "name": "release",
+            "name": "Release",
             "inherits": [
                 "base"
             ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,39 @@
+{
+    "version": 4,
+    "configurePresets": [
+        {
+            "name": "base",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "architecture": {
+                "value": "x64",
+                "strategy": "external"
+            },
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "cl",
+                "CMAKE_CXX_COMPILER": "cl",
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+                "CMAKE_PREFIX_PATH": "${sourceDir}/vendor/out/zlib;${sourceDir}/vendor/out/protobuf;"
+            }
+        },
+        {
+            "name": "debug",
+            "inherits": [
+                "base"
+            ],
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "release",
+            "inherits": [
+                "base"
+            ],
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        }
+    ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,7 +15,7 @@
                 "CMAKE_CXX_COMPILER": "cl",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
                 "CMAKE_PREFIX_PATH": "${sourceDir}/vendor/out/protobuf/${presetName};",
-                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded"
+                "CMAKE_EXPORT_COMPILE_COMMANDS": true
             }
         },
         {
@@ -24,7 +24,8 @@
                 "base"
             ],
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreadedDebug"
             }
         },
         {
@@ -33,7 +34,8 @@
                 "base"
             ],
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded"
             }
         }
     ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,7 +14,8 @@
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
-                "CMAKE_PREFIX_PATH": "${sourceDir}/vendor/out/zlib;${sourceDir}/vendor/out/protobuf;"
+                "CMAKE_PREFIX_PATH": "${sourceDir}/vendor/out/zlib;${sourceDir}/vendor/out/protobuf;",
+                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded"
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,7 +14,7 @@
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
-                "CMAKE_PREFIX_PATH": "${sourceDir}/vendor/out/zlib;${sourceDir}/vendor/out/protobuf;",
+                "CMAKE_PREFIX_PATH": "${sourceDir}/vendor/out/protobuf/${presetName};",
                 "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded"
             }
         },

--- a/demoinfogo/CMakeLists.txt
+++ b/demoinfogo/CMakeLists.txt
@@ -38,3 +38,9 @@ add_executable(demoinfogo
 target_include_directories(demoinfogo PUBLIC ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries(demoinfogo demoinfogo-proto)
+
+# Install the executable.
+#
+install(TARGETS demoinfogo
+    RUNTIME DESTINATION "bin"
+)

--- a/demoinfogo/CMakeLists.txt
+++ b/demoinfogo/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(demoinfogo-proto OBJECT
+    "${CMAKE_CURRENT_LIST_DIR}/cstrike15_usermessages_public.proto"
+    "${CMAKE_CURRENT_LIST_DIR}/netmessages_public.proto"
+)
+
+target_link_libraries(demoinfogo-proto PUBLIC protobuf::libprotobuf)
+
+set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+target_include_directories(demoinfogo-proto PUBLIC "$<BUILD_INTERFACE:${PROTO_BINARY_DIR}>")
+
+protobuf_generate(
+    TARGET demoinfogo-proto
+    IMPORT_DIRS "${CMAKE_CURRENT_LIST_DIR}"
+    PROTOC_OUT_DIR "${PROTO_BINARY_DIR}"
+)

--- a/demoinfogo/CMakeLists.txt
+++ b/demoinfogo/CMakeLists.txt
@@ -1,11 +1,13 @@
-add_library(demoinfogo-proto OBJECT
+# Build protocol buffers.
+#
+add_library(demoinfogo-proto OBJECT STATIC
     "${CMAKE_CURRENT_LIST_DIR}/cstrike15_usermessages_public.proto"
     "${CMAKE_CURRENT_LIST_DIR}/netmessages_public.proto"
 )
 
 target_link_libraries(demoinfogo-proto PUBLIC protobuf::libprotobuf)
 
-set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated_proto")
 
 target_include_directories(demoinfogo-proto PUBLIC "$<BUILD_INTERFACE:${PROTO_BINARY_DIR}>")
 
@@ -14,3 +16,25 @@ protobuf_generate(
     IMPORT_DIRS "${CMAKE_CURRENT_LIST_DIR}"
     PROTOC_OUT_DIR "${PROTO_BINARY_DIR}"
 )
+
+# Build the executable.
+#
+add_executable(demoinfogo
+    demofile.cpp
+    demofile.h
+
+    demofilebitbuf.cpp
+    demofilebitbuf.h
+
+    demofiledump.cpp
+    demofiledump.h
+
+    demofilepropdecode.cpp
+    demofilepropdecode.h
+
+    demoinfogo.cpp
+)
+
+target_include_directories(demoinfogo PUBLIC ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(demoinfogo demoinfogo-proto)

--- a/demoinfogo/README.md
+++ b/demoinfogo/README.md
@@ -33,17 +33,21 @@ csgo-demoinfogo/
   vendor/
     out/
       protobuf/
-        release/
-        debug/
+        Release/
+        Debug/
 ```
 
-To build `demoinfogo` with CMake (in `release` mode), open a Visual Studio developer console and follow these steps:
+To build `demoinfogo` with CMake (in `Release` mode), open a Visual Studio developer console and follow these steps:
 
 ```
-cmake --preset release
-cmake --build out/build/release --target install
+cmake --preset Release
+cmake --build out/build/Release --target install
+```
 
-.\out\install\release\bin\demoinfogo.exe
+The program can be invoked with:
+
+```
+.\out\install\Release\bin\demoinfogo.exe
 ```
 
 Working with Network Messages

--- a/demoinfogo/README.md
+++ b/demoinfogo/README.md
@@ -23,10 +23,9 @@ In order to build demoinfogo on Windows, follow these steps:
 
 Build and install the following libraries using CMake.
 
-* protobuf v21.12: https://github.com/protocolbuffers/protobuf/releases/tag/v21.12
-* zlib v1.2.13 (needed for protobuf): https://github.com/protocolbuffers/protobuf/releases/tag/v21.12
-
-These libraries must be installed into `csgo-demoinfo/vendor/out`.
+* protobuf v21.12: https://github.com/protocolbuffers/protobuf/releases/tag/v21.12. **Note:** You can build with `-Dprotobuf_WITH_ZLIB=OFF` as ZLIB support is not needed.*
+  
+These libraries must be installed into `csgo-demoinfo/vendor/out/{library name}/{preset name}`. For example:
 
 ```
 csgo-demoinfogo/
@@ -34,10 +33,11 @@ csgo-demoinfogo/
   vendor/
     out/
       protobuf/
-      zlib/
+        release/
+        debug/
 ```
 
-To build `demoinfogo` with CMake, follow these steps:
+To build `demoinfogo` with CMake (in `release` mode), open a Visual Studio developer console and follow these steps:
 
 ```
 cmake --preset release

--- a/demoinfogo/README.md
+++ b/demoinfogo/README.md
@@ -8,7 +8,7 @@ Demos and network messages in CS:GO use Google's Protocol Buffers (protobuf). Pr
 Building demoinfogo
 -------------------
 
-### Windows
+### Windows
 
 In order to build demoinfogo on Windows, follow these steps:
 
@@ -18,6 +18,33 @@ In order to build demoinfogo on Windows, follow these steps:
 4. Build the *Release* configuration of `libprotobuf`. Building any other projects is not required.
 5. Open `demoinfogo/demoinfogo.vcxproj` in Microsoft Visual Studio 2010. Building the Release configuration creates the binary `demoinfogo/demoinfogo.exe`
 
+
+### CMake on Windows
+
+Build and install the following libraries using CMake.
+
+* protobuf v21.12: https://github.com/protocolbuffers/protobuf/releases/tag/v21.12
+* zlib v1.2.13 (needed for protobuf): https://github.com/protocolbuffers/protobuf/releases/tag/v21.12
+
+These libraries must be installed into `csgo-demoinfo/vendor/out`.
+
+```
+csgo-demoinfogo/
+  ...
+  vendor/
+    out/
+      protobuf/
+      zlib/
+```
+
+To build `demoinfogo` with CMake, follow these steps:
+
+```
+cmake --preset release
+cmake --build out/build/release --target install
+
+.\out\install\release\bin\demoinfogo.exe
+```
 
 Working with Network Messages
 -----------------------------

--- a/demoinfogo/cstrike15_usermessages_public.proto
+++ b/demoinfogo/cstrike15_usermessages_public.proto
@@ -27,6 +27,8 @@
 //
 //=============================================================================
 
+syntax = "proto2";
+
 // We care more about speed than code size
 option optimize_for = SPEED;
 

--- a/demoinfogo/netmessages_public.proto
+++ b/demoinfogo/netmessages_public.proto
@@ -35,7 +35,7 @@
 // There is an important difference between the signed int types (sint32 and sint64)
 // and the "standard" int types (int32 and int64) when it comes to encoding negative
 // numbers.  If you use int32 or int64 as the type for a negative number, the
-// resulting varint is always ten bytes long – it is, effectively, treated like a
+// resulting varint is always ten bytes long - it is, effectively, treated like a
 // very large unsigned integer.  If you use one of the signed types, the resulting
 // varint uses ZigZag encoding, which is much more efficient.
 

--- a/demoinfogo/netmessages_public.proto
+++ b/demoinfogo/netmessages_public.proto
@@ -39,6 +39,7 @@
 // very large unsigned integer.  If you use one of the signed types, the resulting
 // varint uses ZigZag encoding, which is much more efficient.
 
+syntax = "proto2";
 
 // Commenting this out allows it to be compiled for SPEED or LITE_RUNTIME.
 // option optimize_for = SPEED;


### PR DESCRIPTION
This PR adds support for building `demoinfogo` with CMake. Compatibility with the previous build method is retained.

#### Changes

* Add CMake build scripts.
* Added build instructions to `demoinfogo/README.md`.
* Add basic `CMakePresets.json` for building on Windows.